### PR TITLE
Change README to use the correct makefile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ With bazel:
 
 With Makefile:
 ```bash
-  make pip_pkg
+  make zero_out_pip_pkg
 ```
 
 ### Install and Test PIP Package


### PR DESCRIPTION
## Problem

The README suggests that users try the following

```
make pip_pkg
```

but `pip_pkg` does not appear in the makefile and that results in the following error:

```
make: *** No rule to make target 'pip_pkg'.  Stop.
```

I suspect this repository was modified from having one op (the CPU op) to two ops (including the GPU op).  When the makefile had both ops separated, the README simply fell behind.

## Fix

I simply changed the suggested makefile command to the following

```
make zero_out_pip_pkg
```

which gives the following (correct) output:

```
g++ -I/usr/local/lib/python3.6/dist-packages/tensorflow/include -D_GLIBCXX_USE_CXX11_ABI=0 -fPIC -O2 -std=c++11 -o tensorflow_zero_out/python/ops/_zero_out_ops.so tensorflow_zero_out/cc/kernels/zero_out_kernels.cc tensorflow_zero_out/cc/ops/zero_out_ops.cc -shared -L/usr/local/lib/python3.6/dist-packages/tensorflow -ltensorflow_framework
./build_pip_pkg.sh make artifacts
++ tr A-Z a-z
++ uname -s
+ PLATFORM=linux
+ PIP_FILE_PREFIX=bazel-bin/build_pip_pkg.runfiles/__main__/
+ main make artifacts
+ [[ ! -z make ]]
+ [[ make == \m\a\k\e ]]
+ echo 'Using Makefile to build pip package.'
Using Makefile to build pip package.
+ PIP_FILE_PREFIX=
+ shift
+ [[ ! -z artifacts ]]
+ [[ artifacts == \m\a\k\e ]]
+ DEST=artifacts
+ shift
+ [[ ! -z '' ]]
+ [[ -z artifacts ]]
+ mkdir -p artifacts
++ readlink -f artifacts
+ DEST=/content/custom-op/artifacts
+ echo '=== destination directory: /content/custom-op/artifacts'
=== destination directory: /content/custom-op/artifacts
++ mktemp -d -t tmp.XXXXXXXXXX
+ TMPDIR=/tmp/tmp.eh1yUx5cVx
++ date
+ echo Sat Jun 8 05:47:11 UTC 2019 : '=== Using tmpdir: /tmp/tmp.eh1yUx5cVx'
Sat Jun 8 05:47:11 UTC 2019 : === Using tmpdir: /tmp/tmp.eh1yUx5cVx
+ echo '=== Copy TensorFlow Zero Out files'
=== Copy TensorFlow Zero Out files
+ cp setup.py /tmp/tmp.eh1yUx5cVx
+ cp MANIFEST.in /tmp/tmp.eh1yUx5cVx
+ cp LICENSE /tmp/tmp.eh1yUx5cVx
+ rsync -avm -L '--exclude=*_test.py' tensorflow_zero_out /tmp/tmp.eh1yUx5cVx
tensorflow_zero_out/
tensorflow_zero_out/BUILD
tensorflow_zero_out/__init__.py
tensorflow_zero_out/cc/
tensorflow_zero_out/cc/kernels/
tensorflow_zero_out/cc/kernels/zero_out_kernels.cc
tensorflow_zero_out/cc/ops/
tensorflow_zero_out/cc/ops/zero_out_ops.cc
tensorflow_zero_out/python/
tensorflow_zero_out/python/__init__.py
tensorflow_zero_out/python/ops/
tensorflow_zero_out/python/ops/__init__.py
tensorflow_zero_out/python/ops/_zero_out_ops.so
tensorflow_zero_out/python/ops/zero_out_ops.py

sent 38,211 bytes  received 186 bytes  76,794.00 bytes/sec
total size is 37,432  speedup is 0.97
+ pushd /tmp/tmp.eh1yUx5cVx
/tmp/tmp.eh1yUx5cVx /content/custom-op
++ date
+ echo Sat Jun 8 05:47:11 UTC 2019 : '=== Building wheel'
Sat Jun 8 05:47:11 UTC 2019 : === Building wheel
+ python setup.py bdist_wheel
+ cp dist/tensorflow_zero_out-0.0.1-cp36-cp36m-linux_x86_64.whl /content/custom-op/artifacts
+ popd
/content/custom-op
+ rm -rf /tmp/tmp.eh1yUx5cVx
++ date
+ echo Sat Jun 8 05:47:12 UTC 2019 : '=== Output wheel file is in: /content/custom-op/artifacts'
Sat Jun 8 05:47:12 UTC 2019 : === Output wheel file is in: /content/custom-op/artifacts
```

and verified that the rest of the steps work correctly.  The pip install works:

```
pip install artifacts/*.whl

Processing ./artifacts/tensorflow_zero_out-0.0.1-cp36-cp36m-linux_x86_64.whl
Requirement already satisfied: tensorflow>=1.12.0 in /usr/local/lib/python3.6/dist-packages (from tensorflow-zero-out==0.0.1) (1.13.1)
...
Requirement already satisfied: werkzeug>=0.11.15 in /usr/local/lib/python3.6/dist-packages (from tensorboard<1.14.0,>=1.13.0->tensorflow>=1.12.0->tensorflow-zero-out==0.0.1) (0.15.4)
Installing collected packages: tensorflow-zero-out
Successfully installed tensorflow-zero-out-0.0.1
```

and the actual custom op functions as expected:

```python
import tensorflow as tf
import tensorflow_zero_out as zero_out_module

t = [[1,2], [3,4]]
zeroed = zero_out_module.zero_out(t).eval(session=tf.Session())
print(zeroed)
# [[1 0]
#  [0 0]]
```