### PR TITLE
Avoid readlink -f on macOS

### DIFF
--- a/build_pip_pkg.sh
+++ b/build_pip_pkg.sh
@@ -41,7 +41,7 @@ function main() {
   # directory.
   mkdir -p ${DEST}
   if [[ ${PLATFORM} == "darwin" ]]; then
-    DEST=$(pwd)/${DEST}
+    DEST=$(pwd -P)/${DEST}
   else
     DEST=$(readlink -f "${DEST}")
   fi

--- a/build_pip_pkg.sh
+++ b/build_pip_pkg.sh
@@ -40,7 +40,11 @@ function main() {
   # give us an absolute paths with tilde characters resolved to the destination
   # directory.
   mkdir -p ${DEST}
-  DEST=$(readlink -f "${DEST}")
+  if [[ ${PLATFORM} == "darwin" ]]; then
+    DEST=$(pwd)/${DEST}
+  else
+    DEST=$(readlink -f "${DEST}")
+  fi
   echo "=== destination directory: ${DEST}"
 
   TMPDIR=$(mktemp -d -t tmp.XXXXXXXXXX)


### PR DESCRIPTION
As noted by https://github.com/tensorflow/custom-op/issues/7#issuecomment-459502616, `readlink -f` fails on macOS. After this change, I can build the pip package on macOS without problems.