### PR TITLE
Build with experimental preprocessor for Windows

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -142,6 +142,12 @@ write_to_bazelrc "build --spawn_strategy=standalone"
 write_to_bazelrc "build --strategy=Genrule=standalone"
 write_to_bazelrc "build -c opt"
 
+# MSVC (Windows): Standards-conformant preprocessor mode
+# See https://docs.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview
+if is_windows; then
+  write_to_bazelrc "build --copt=/experimental:preprocessor"
+  write_to_bazelrc "build --host_copt=/experimental:preprocessor"
+fi
 
 if is_windows; then
   # Use pywrap_tensorflow instead of tensorflow_framework on Windows


### PR DESCRIPTION
As of TF2.4 custom-ops will fail to compile using MSVC unless the experimental preprocessor flag is set. This is backwards compatible and will work for previous versions of TF linking.

SIG Build thread:
https://groups.google.com/a/tensorflow.org/g/build/c/LbAw8RILvTg/m/ttnuhYU2BgAJ

Root cause commit:
https://github.com/tensorflow/tensorflow/commit/5aa11f9c5e7a6071f2d0a774c9e43d46be08ec78

TF2.4 Release Note:
https://github.com/tensorflow/tensorflow/pull/44220#issuecomment-736101033

