### PR TITLE
fix copy command causing stack overflow in bash on windows

### DIFF
--- a/tf/tf_configure.bzl
+++ b/tf/tf_configure.bzl
@@ -171,7 +171,7 @@ def _symlink_genrule_for_dir(
     dest_dir = "abc"
     genrule = _genrule(
         genrule_name,
-        " && ".join(command),
+        "\n".join(command),
         "\n".join(outs),
     )
     return genrule


### PR DESCRIPTION
Fixes the issue described in #87. Putting together all copy command for tf headers in tf_configure.bzl via ' && ' causes a stack overflow in msys2 bash.exe on Windows. Executing them as single commands each (via '\n') prevents this. 