### PR TITLE
Fix stack overflow of bash when copying tf headers

### DIFF
--- a/tf/tf_configure.bzl
+++ b/tf/tf_configure.bzl
@@ -171,7 +171,7 @@ def _symlink_genrule_for_dir(
     dest_dir = "abc"
     genrule = _genrule(
         genrule_name,
-        " && ".join(command),
+        "\n".join(command),
         "\n".join(outs),
     )
     return genrule


### PR DESCRIPTION
Fixes issue described in #87. Putting together the copy command for tf headers in tf_configure.bzl using " && " causes a stack overflow in msys2 bash.exe on windows. Executing each copy as a single command (via "\n") prevents this. 